### PR TITLE
Add trim to line

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,7 +113,7 @@
           var content = [];
 
           for(var i = 0; i < lines.length; i++){
-            s = lines[i];
+            s = lines[i].trim();
 
             switch(state) {
 


### PR DESCRIPTION
For some reason, I've been encountering subtitles where there's a non-visible whitespace character on each line, which causes the regex match to fail. Trimming the string appears to solve the issue. :|

I've tried randomly-selected subtitle files from opensubtitles.org, and other various sites, and I see the same issue on all of them.

On srtmerge.github.io:
![image](https://github.com/srtmerge/srtmerge.github.io/assets/5668416/ad8505ee-47b1-45fa-807d-5855d432c2a1)

On local with fix:
![image](https://github.com/srtmerge/srtmerge.github.io/assets/5668416/73966059-4cb8-4edc-9db9-563b06d320dd)

Notice that the sample subtitle is empty on srtmerge.

All 👍 for a more appropriate fix if this isn't the proper way.