### PR TITLE
DOS/Windows srt files have lines ending with \r\n

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
           for(var i = 0; i < lines.length; i++){
             s = lines[i];
             // DOS/Windows srt files have lines ending with \r\n
-            if (s.charAt(s.length - 1) == "\r") {
+            if (s != "" && s.charAt(s.length - 1) == "\r") {
               s = s.slice(0, -1);
             }
 

--- a/index.html
+++ b/index.html
@@ -114,6 +114,10 @@
 
           for(var i = 0; i < lines.length; i++){
             s = lines[i];
+            // DOS/Windows srt files have lines ending with \r\n
+            if (s.charAt(s.length - 1) == "\r") {
+              s = s.slice(0, -1);
+            }
 
             switch(state) {
 


### PR DESCRIPTION
DOS/Windows srt files have lines ending with \r\n resulting in lines which end with a \r character which must be removed for correct parsing to occur.